### PR TITLE
feat: Enable viewing past diagram checkpoints in read-only mode

### DIFF
--- a/src/app/api/diagrams/[id]/checkpoint/route.ts
+++ b/src/app/api/diagrams/[id]/checkpoint/route.ts
@@ -1,5 +1,5 @@
 import { csrfFailureResponse, ensureCsrfCookie, validateCsrfToken } from '@/lib/csrf';
-import { createCheckpoint, getDiagramById, listCheckpoints } from '@/lib/data';
+import { createCheckpoint, deleteCheckpoint, getDiagramById, listCheckpoints, restoreCheckpoint } from '@/lib/data';
 import { logApiError } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 
@@ -57,5 +57,74 @@ export async function POST(
   } catch (error) {
     logApiError('POST /api/diagrams/[id]/checkpoint', error);
     return NextResponse.json({ error: 'Failed to create checkpoint' }, { status: 500 });
+  }
+}
+
+/**
+ * Restore a checkpoint as the current version
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await validateCsrfToken(request))) {
+    return csrfFailureResponse();
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const checkpointId = body?.checkpointId;
+
+    if (typeof checkpointId !== 'string' || !checkpointId.length) {
+      return NextResponse.json({ error: 'checkpointId is required' }, { status: 400 });
+    }
+
+    const result = await restoreCheckpoint(id, checkpointId);
+
+    if (!result) {
+      return NextResponse.json({ error: 'Checkpoint not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logApiError('PATCH /api/diagrams/[id]/checkpoint', error);
+    return NextResponse.json({ error: 'Failed to restore checkpoint' }, { status: 500 });
+  }
+}
+
+/**
+ * Delete a checkpoint
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await validateCsrfToken(request))) {
+    return csrfFailureResponse();
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const checkpointId = body?.checkpointId;
+
+    if (typeof checkpointId !== 'string' || !checkpointId.length) {
+      return NextResponse.json({ error: 'checkpointId is required' }, { status: 400 });
+    }
+
+    const deleted = await deleteCheckpoint(id, checkpointId);
+
+    if (!deleted) {
+      return NextResponse.json({ error: 'Checkpoint not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Cannot delete the current checkpoint') {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    logApiError('DELETE /api/diagrams/[id]/checkpoint', error);
+    return NextResponse.json({ error: 'Failed to delete checkpoint' }, { status: 500 });
   }
 }

--- a/src/components/CheckpointHistory.tsx
+++ b/src/components/CheckpointHistory.tsx
@@ -9,8 +9,18 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import { History, Plus, Loader2 } from 'lucide-react';
+import { History, Plus, Loader2, Trash2, RotateCcw, Check } from 'lucide-react';
 import { Checkpoint } from '@/lib/types';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatDate } from '@/lib/utils';
@@ -18,75 +28,165 @@ import { useState } from 'react';
 
 interface CheckpointHistoryProps {
     checkpoints: Checkpoint[];
+    currentCheckpointId?: string;
+    viewingCheckpointId?: string | null;
     isLoading: boolean;
     isSaving: boolean;
     onCreateCheckpoint: () => void;
-    onRestoreCheckpoint: (id: string) => void;
+    onViewCheckpoint: (id: string) => void;
+    onMakeCurrent: (id: string) => void;
+    onDeleteCheckpoint: (id: string) => void;
 }
 
 export function CheckpointHistory({
     checkpoints,
+    currentCheckpointId,
+    viewingCheckpointId,
     isLoading,
     isSaving,
     onCreateCheckpoint,
-    onRestoreCheckpoint,
+    onViewCheckpoint,
+    onMakeCurrent,
+    onDeleteCheckpoint,
 }: CheckpointHistoryProps) {
     const [open, setOpen] = useState(false);
+    const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+    const handleDelete = (e: React.MouseEvent, id: string) => {
+        e.stopPropagation();
+        setDeleteConfirmId(id);
+    };
+
+    const confirmDelete = () => {
+        if (deleteConfirmId) {
+            onDeleteCheckpoint(deleteConfirmId);
+            setDeleteConfirmId(null);
+        }
+    };
+
+    const handleMakeCurrent = (e: React.MouseEvent, id: string) => {
+        e.stopPropagation();
+        onMakeCurrent(id);
+        setOpen(false);
+    };
 
     return (
-        <DropdownMenu open={open} onOpenChange={setOpen}>
-            <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" title="History & Checkpoints">
-                    <History className="h-4 w-4" />
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-80">
-                <DropdownMenuLabel className="flex items-center justify-between">
-                    <span>History</span>
-                    <span className="text-xs font-normal text-muted-foreground">{checkpoints.length} versions</span>
-                </DropdownMenuLabel>
-
-                <div className="p-2">
-                    <Button
-                        size="sm"
-                        className="w-full justify-start gap-2"
-                        onClick={onCreateCheckpoint}
-                        disabled={isSaving}
-                    >
-                        {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-                        Create Checkpoint
+        <>
+            <DropdownMenu open={open} onOpenChange={setOpen}>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" title="History & Checkpoints">
+                        <History className="h-4 w-4" />
                     </Button>
-                </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-80">
+                    <DropdownMenuLabel className="flex items-center justify-between">
+                        <span>History</span>
+                        <span className="text-xs font-normal text-muted-foreground">{checkpoints.length} versions</span>
+                    </DropdownMenuLabel>
 
-                <DropdownMenuSeparator />
+                    <div className="p-2">
+                        <Button
+                            size="sm"
+                            className="w-full justify-start gap-2"
+                            onClick={onCreateCheckpoint}
+                            disabled={isSaving}
+                        >
+                            {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                            Create Checkpoint
+                        </Button>
+                    </div>
 
-                <ScrollArea className="h-[300px]">
-                    {isLoading ? (
-                        <div className="p-4 text-center text-sm text-muted-foreground">Loading...</div>
-                    ) : checkpoints.length === 0 ? (
-                        <div className="p-4 text-center text-sm text-muted-foreground">
-                            No checkpoints yet.
-                        </div>
-                    ) : (
-                        <div className="py-1">
-                            {checkpoints.map((cp) => (
-                                <DropdownMenuItem
-                                    key={cp.id}
-                                    onClick={() => onRestoreCheckpoint(cp.id)}
-                                    className="flex flex-col items-start gap-1 py-3 cursor-pointer"
-                                >
-                                    <span className="font-medium text-sm">
-                                        {formatDate(cp.updatedAt)}
-                                    </span>
-                                    <span className="text-xs text-muted-foreground line-clamp-2">
-                                        {cp.content.slice(0, 60).replace(/\n/g, ' ')}...
-                                    </span>
-                                </DropdownMenuItem>
-                            ))}
-                        </div>
-                    )}
-                </ScrollArea>
-            </DropdownMenuContent>
-        </DropdownMenu>
+                    <DropdownMenuSeparator />
+
+                    <ScrollArea className="h-[300px]">
+                        {isLoading ? (
+                            <div className="p-4 text-center text-sm text-muted-foreground">Loading...</div>
+                        ) : checkpoints.length === 0 ? (
+                            <div className="p-4 text-center text-sm text-muted-foreground">
+                                No checkpoints yet.
+                            </div>
+                        ) : (
+                            <div className="py-1">
+                                {checkpoints.map((cp, index) => {
+                                    const isCurrent = index === 0 || cp.id === currentCheckpointId;
+                                    const isViewing = cp.id === viewingCheckpointId;
+
+                                    return (
+                                        <DropdownMenuItem
+                                            key={cp.id}
+                                            onClick={() => onViewCheckpoint(cp.id)}
+                                            className="flex flex-col items-start gap-1 py-3 cursor-pointer group"
+                                        >
+                                            <div className="flex items-center justify-between w-full">
+                                                <div className="flex items-center gap-2">
+                                                    <span className="font-medium text-sm">
+                                                        {formatDate(cp.updatedAt)}
+                                                    </span>
+                                                    {isCurrent && (
+                                                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium bg-primary/10 text-primary rounded">
+                                                            <Check className="h-3 w-3" />
+                                                            Current
+                                                        </span>
+                                                    )}
+                                                    {isViewing && !isCurrent && (
+                                                        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground rounded">
+                                                            Viewing
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                                    {!isCurrent && (
+                                                        <>
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-6 w-6"
+                                                                onClick={(e) => handleMakeCurrent(e, cp.id)}
+                                                                title="Make current"
+                                                            >
+                                                                <RotateCcw className="h-3 w-3" />
+                                                            </Button>
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-6 w-6 text-destructive hover:text-destructive"
+                                                                onClick={(e) => handleDelete(e, cp.id)}
+                                                                title="Delete checkpoint"
+                                                            >
+                                                                <Trash2 className="h-3 w-3" />
+                                                            </Button>
+                                                        </>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            <span className="text-xs text-muted-foreground line-clamp-2">
+                                                {cp.content.slice(0, 60).replace(/\n/g, ' ')}...
+                                            </span>
+                                        </DropdownMenuItem>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </ScrollArea>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <AlertDialog open={!!deleteConfirmId} onOpenChange={(open) => !open && setDeleteConfirmId(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Checkpoint?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This will permanently delete this checkpoint. This action cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
     );
 }

--- a/src/components/DiagramEditor.tsx
+++ b/src/components/DiagramEditor.tsx
@@ -41,7 +41,7 @@ import { Checkpoint, Diagram, Tag } from '@/lib/types';
 import { useLiveSync } from '@/lib/useLiveSync';
 import { useShortcutPlatform } from '@/lib/use-platform';
 import { copyToClipboard, formatDate, cn } from '@/lib/utils';
-import { History, Info, Moon, Save, Search, Share2, Star, Sun, Menu, Settings2, Trash2, MoreHorizontal } from 'lucide-react';
+import { History, Info, Moon, Save, Search, Share2, Star, Sun, Menu, Settings2, Trash2, MoreHorizontal, RotateCcw, AlertCircle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import dynamic from 'next/dynamic';
@@ -252,6 +252,7 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
   const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
   const [isLoadingCheckpoints, setIsLoadingCheckpoints] = useState(false);
   const [isSavingCheckpoint, setIsSavingCheckpoint] = useState(false);
+  const [viewingCheckpointId, setViewingCheckpointId] = useState<string | null>(null);
   const { setTheme, theme } = useTheme();
   const settings = useDiagramStore((state) => state.settings);
   const updateDiagram = useDiagramStore((state) => state.updateDiagram);
@@ -326,6 +327,8 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
   }, [diagram.content, selectedNodeId]);
 
   const handleEditorChange = (value: string) => {
+    // Ignore changes when viewing a past checkpoint (read-only mode)
+    if (viewingCheckpointId !== null) return;
     setDiagram((prev) => ({ ...prev, content: value }));
   };
 
@@ -422,16 +425,22 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
+        // Don't save when viewing a past checkpoint
+        if (viewingCheckpointId !== null) {
+          toast.info('Cannot save while viewing a past checkpoint');
+          return;
+        }
         saveChanges();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [saveChanges]);
+  }, [saveChanges, viewingCheckpointId]);
 
   // Auto-save with debounce
   useEffect(() => {
-    if (!settings.autoSave) return;
+    // Don't auto-save when viewing a past checkpoint
+    if (!settings.autoSave || viewingCheckpointId !== null) return;
 
     const hasContentChanged = diagram.content !== lastSavedContentRef.current;
     const hasTitleChanged = diagram.title !== lastSavedTitleRef.current;
@@ -455,11 +464,12 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
         clearTimeout(autoSaveTimerRef.current);
       }
     };
-  }, [diagram.content, diagram.title, diagram.description, tags, settings.autoSave, saveChanges]);
+  }, [diagram.content, diagram.title, diagram.description, tags, settings.autoSave, saveChanges, viewingCheckpointId]);
 
   // Save on blur for title (if auto-save is off)
   const handleTitleBlur = () => {
-    if (!settings.autoSave) {
+    // Don't save when viewing a past checkpoint
+    if (!settings.autoSave && viewingCheckpointId === null) {
       saveChanges();
     }
   };
@@ -569,13 +579,99 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
     }
   }, [diagram, updateDiagram]);
 
-  const handleSelectCheckpoint = (checkpointId: string) => {
+  const handleViewCheckpoint = useCallback((checkpointId: string) => {
     const checkpoint = checkpoints.find((cp) => cp.id === checkpointId);
     if (!checkpoint) return;
+
+    // If viewing the current (first) checkpoint, clear viewing mode
+    if (checkpoints[0]?.id === checkpointId) {
+      setViewingCheckpointId(null);
+      return;
+    }
+
+    setViewingCheckpointId(checkpointId);
     setDiagram((prev) => ({ ...prev, content: checkpoint.content }));
-    updateDiagram(diagram.id, { content: checkpoint.content });
-    toast.success('Checkpoint loaded');
-  };
+    toast.info('Viewing past checkpoint (read-only)');
+  }, [checkpoints]);
+
+  const handleMakeCurrent = useCallback(async (checkpointId: string) => {
+    try {
+      const csrfToken = await ensureCsrfToken();
+      const res = await fetch(`/api/diagrams/${diagram.id}/checkpoint`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          [CSRF_HEADER_NAME]: csrfToken,
+        },
+        body: JSON.stringify({ checkpointId }),
+      });
+      if (!res.ok) throw new Error('Failed to restore checkpoint');
+      const data = await res.json();
+
+      // Update diagram with restored content
+      setDiagram(data.diagram);
+      lastSavedContentRef.current = data.diagram.content;
+      lastSavedTitleRef.current = data.diagram.title;
+      lastSavedDescriptionRef.current = data.diagram.description;
+      updateDiagram(diagram.id, data.diagram);
+
+      // Add new checkpoint to list
+      setCheckpoints((prev) => {
+        const next = [data.checkpoint as Checkpoint, ...prev.filter((cp) => cp.id !== data.checkpoint.id)];
+        return next.slice(0, MAX_CHECKPOINTS);
+      });
+
+      // Clear viewing mode
+      setViewingCheckpointId(null);
+      toast.success('Checkpoint restored as current');
+    } catch {
+      toast.error('Failed to restore checkpoint');
+    }
+  }, [diagram.id, updateDiagram]);
+
+  const handleDeleteCheckpoint = useCallback(async (checkpointId: string) => {
+    try {
+      const csrfToken = await ensureCsrfToken();
+      const res = await fetch(`/api/diagrams/${diagram.id}/checkpoint`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          [CSRF_HEADER_NAME]: csrfToken,
+        },
+        body: JSON.stringify({ checkpointId }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to delete checkpoint');
+      }
+
+      // Remove from list
+      setCheckpoints((prev) => prev.filter((cp) => cp.id !== checkpointId));
+
+      // If we were viewing the deleted checkpoint, go back to current
+      if (viewingCheckpointId === checkpointId) {
+        setViewingCheckpointId(null);
+        // Reload current content
+        loadCheckpoints();
+      }
+
+      toast.success('Checkpoint deleted');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete checkpoint');
+    }
+  }, [diagram.id, viewingCheckpointId, loadCheckpoints]);
+
+  // When returning to current (clearing viewingCheckpointId), reload current content
+  useEffect(() => {
+    if (viewingCheckpointId === null && checkpoints.length > 0) {
+      const currentCheckpoint = checkpoints[0];
+      if (currentCheckpoint && diagram.content !== currentCheckpoint.content) {
+        setDiagram((prev) => ({ ...prev, content: currentCheckpoint.content }));
+      }
+    }
+  }, [viewingCheckpointId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isViewingPastCheckpoint = viewingCheckpointId !== null;
 
   // Show loading state until client hydration is complete
   if (!mounted) {
@@ -640,10 +736,14 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
             {/* Checkpoints */}
             <CheckpointHistory
               checkpoints={checkpoints}
+              currentCheckpointId={checkpoints[0]?.id}
+              viewingCheckpointId={viewingCheckpointId}
               isLoading={isLoadingCheckpoints}
               isSaving={isSavingCheckpoint}
               onCreateCheckpoint={handleSaveCheckpoint}
-              onRestoreCheckpoint={handleSelectCheckpoint}
+              onViewCheckpoint={handleViewCheckpoint}
+              onMakeCurrent={handleMakeCurrent}
+              onDeleteCheckpoint={handleDeleteCheckpoint}
             />
 
             {/* Desktop only actions moved to overflow menu on mobile if needed, but fitting key ones here */}
@@ -703,7 +803,25 @@ export function DiagramEditor({ initialDiagram }: DiagramEditorProps) {
           </Link>
         </div>
 
-        <div className="flex-1 min-h-0">
+        <div className="flex-1 min-h-0 flex flex-col">
+          {/* Read-only banner when viewing past checkpoint */}
+          {isViewingPastCheckpoint && (
+            <div className="bg-amber-500/10 border-b border-amber-500/20 px-4 py-2 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+                <AlertCircle className="h-4 w-4" />
+                <span>Viewing past checkpoint (read-only)</span>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-2 border-amber-500/30 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                onClick={() => viewingCheckpointId && handleMakeCurrent(viewingCheckpointId)}
+              >
+                <RotateCcw className="h-3 w-3" />
+                Make Current
+              </Button>
+            </div>
+          )}
           <div className="sm:hidden border-b bg-muted/30 px-3 py-2 flex items-center gap-2">
             <button
               type="button"

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -479,6 +479,145 @@ export async function createCheckpoint(
   return { checkpoint: result.checkpoint, diagram: toDiagram(result.diagram) };
 }
 
+/**
+ * Delete a specific checkpoint from a diagram.
+ * Cannot delete the latest (current) checkpoint.
+ */
+export async function deleteCheckpoint(
+  diagramId: string,
+  checkpointId: string
+): Promise<boolean> {
+  return withTx(async (tx: TransactionClient) => {
+    // Check if checkpoint exists and belongs to this diagram
+    const checkpoint = await tx.content.findFirst({
+      where: { id: checkpointId, diagramId },
+    });
+
+    if (!checkpoint) return false;
+
+    // Get the latest checkpoint to prevent deleting current
+    const latest = await tx.content.findFirst({
+      where: { diagramId },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    if (latest?.id === checkpointId) {
+      throw new Error('Cannot delete the current checkpoint');
+    }
+
+    // Delete the checkpoint
+    await tx.content.delete({ where: { id: checkpointId } });
+
+    // Update totalVersions
+    const count = await tx.content.count({ where: { diagramId } });
+    await tx.diagram.update({
+      where: { id: diagramId },
+      data: { totalVersions: count },
+    });
+
+    return true;
+  });
+}
+
+/**
+ * Restore a checkpoint as the current version.
+ * Creates a new checkpoint with the restored content.
+ */
+export async function restoreCheckpoint(
+  diagramId: string,
+  checkpointId: string
+): Promise<{ checkpoint: Checkpoint; diagram: Diagram } | null> {
+  const now = new Date();
+
+  return withTx(async (tx: TransactionClient) => {
+    // Get the checkpoint to restore
+    const checkpoint = await tx.content.findFirst({
+      where: { id: checkpointId, diagramId },
+    });
+
+    if (!checkpoint) return null;
+
+    // Get current diagram
+    const diagram = await tx.diagram.findUnique({
+      where: { id: diagramId },
+      select: {
+        title: true,
+        description: true,
+        emoji: true,
+        isFavorite: true,
+        totalVersions: true,
+      },
+    });
+
+    if (!diagram) return null;
+
+    // Create new checkpoint with the restored content
+    const newCheckpointId = await ensureUniqueId(async (candidate) => {
+      const found = await tx.content.findUnique({
+        where: { id: candidate },
+        select: { id: true },
+      });
+      return Boolean(found);
+    });
+
+    await tx.content.create({
+      data: {
+        id: newCheckpointId,
+        diagramId,
+        content: checkpoint.content,
+        updatedAt: now,
+      },
+    });
+
+    // Update diagram timestamp and search vector
+    await tx.diagram.update({
+      where: { id: diagramId },
+      data: {
+        updatedAt: now,
+        searchVector: buildSearchVector(diagram.title, diagram.description, checkpoint.content),
+      },
+    });
+
+    // Prune old checkpoints if over limit
+    const extraContents = await tx.content.findMany({
+      where: { diagramId },
+      orderBy: { updatedAt: 'desc' },
+      skip: MAX_CHECKPOINTS,
+      select: { id: true },
+    });
+
+    if (extraContents.length > 0) {
+      await tx.content.deleteMany({
+        where: { id: { in: extraContents.map((c: { id: string }) => c.id) } },
+      });
+    }
+
+    const prunedCount = extraContents.length;
+
+    await tx.diagram.update({
+      where: { id: diagramId },
+      data: { totalVersions: diagram.totalVersions + 1 - prunedCount },
+    });
+
+    // Get updated diagram
+    const latest = await tx.diagram.findUnique({
+      where: { id: diagramId },
+      select: diagramWithLatestSelect,
+    });
+
+    if (!latest) return null;
+
+    return {
+      checkpoint: {
+        id: newCheckpointId,
+        content: checkpoint.content,
+        updatedAt: now.toISOString(),
+      },
+      diagram: toDiagram(latest as DiagramWithLatest),
+    };
+  });
+}
+
 export async function deleteDiagramById(id: string): Promise<boolean> {
   try {
     await prisma.diagram.delete({ where: { id } });


### PR DESCRIPTION
This pull request introduces significant improvements to the diagram checkpoint system, adding the ability to view, restore, and delete past checkpoints, as well as enhancing the user interface to clearly indicate when a user is viewing a past (read-only) checkpoint. The changes include new API endpoints for restoring and deleting checkpoints, updates to the UI for checkpoint management, and logic to prevent editing when viewing historical checkpoints.

**Checkpoint management features:**

* Added `PATCH` and `DELETE` API endpoints in `src/app/api/diagrams/[id]/checkpoint/route.ts` to allow restoring a checkpoint as the current version and deleting a checkpoint, respectively. ([src/app/api/diagrams/[id]/checkpoint/route.tsR62-R130](diffhunk://#diff-ab54cae32081e251576ea6e1d4316e8c9b63332358c5efe387fe852d1822d651R62-R130))
* Updated the `CheckpointHistory` component to support viewing, restoring, and deleting checkpoints, including UI feedback for the current and viewing checkpoints, and a confirmation dialog for deletions. [[1]](diffhunk://#diff-38499f084da2fdf4893766c718976473ba517d37577ac7922f8fdd6803194d55R12-R74) [[2]](diffhunk://#diff-38499f084da2fdf4893766c718976473ba517d37577ac7922f8fdd6803194d55L72-R190)

**Editor behavior and UI enhancements:**

* Enhanced `DiagramEditor` to support read-only mode when viewing a past checkpoint, including disabling editing, auto-save, and save shortcuts, and displaying a prominent banner with an action to restore the viewed checkpoint as current. [[1]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5R330-R331) [[2]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5R428-R443) [[3]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5L458-R472) [[4]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5L706-R824)
* Implemented logic in `DiagramEditor` to handle checkpoint viewing, restoring, and deletion, ensuring the editor state and checkpoint list are correctly synchronized. [[1]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5L572-R674) [[2]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5R739-R746)

**Supporting changes:**

* Updated imports and props throughout the affected components to support the new checkpoint management functionality. ([src/app/api/diagrams/[id]/checkpoint/route.tsL2-R2](diffhunk://#diff-ab54cae32081e251576ea6e1d4316e8c9b63332358c5efe387fe852d1822d651L2-R2), [[1]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5L44-R44) [[2]](diffhunk://#diff-7b201cf71f63c8ee921551b654a8cdafc827a2657f1ee7c929e580f9835844d5R255)