### PR TITLE
build-fix: remove emf2svg package from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/data ./data
 RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data
 
 # Install TeX Live for LaTeX support
-RUN apk add --no-cache texlive-full fontconfig emf2svg
+RUN apk add --no-cache texlive-full fontconfig
 
 
 # Switch to non-root user
@@ -120,4 +120,3 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Start via entrypoint (generates Prisma client + syncs schema at runtime)
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
-


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by removing the `emf2svg` package from the list of installed dependencies. This simplifies the image and reduces unnecessary dependencies. No other significant changes are included.

- Dependency updates:
  * Removed the installation of the `emf2svg` package from the `Dockerfile` to streamline dependencies.